### PR TITLE
fix: make discord link an invite link for real tho

### DIFF
--- a/content/footer.md
+++ b/content/footer.md
@@ -23,6 +23,6 @@ build:
 - [<i class="fa-brands fa-youtube"></i>](https://www.youtube.com/user/anthrocon "YouTube")
 - [<i class="fa-brands fa-telegram"></i>](https://telegram.me/Anthrocon "Telegram")
 - [<i class="fa-brands fa-flickr"></i>](https://www.flickr.com/anthrocon "Flickr")
-- [<i class="fa-brands fa-discord"></i>](https://discord.com/channels/248272223868157954/249930108922626050/1212257650314584065 "Discord")
+- [<i class="fa-brands fa-discord"></i>](https://discord.gg/anthrocon-248272223868157954 "Discord")
 
 </nav>


### PR DESCRIPTION
because we shouldn't link directly to a channel